### PR TITLE
Feature: Include RFID Logs in Equipment Log Book report

### DIFF
--- a/equipment_management/equipment_management/report/equipment_log_book/equipment_log_book.py
+++ b/equipment_management/equipment_management/report/equipment_log_book/equipment_log_book.py
@@ -166,6 +166,26 @@ where
     eq.name = mem.equipment and
     eq.name = "{4}"  and
     doctype.name = 'Manual Equipment Movement'
-    order by `pd` desc'''.format(equipment,equipment,equipment,equipment,equipment)
+
+union
+select
+    rl.datetime,
+    eq.name,
+    eq.indicator,
+    eq.status,
+    eq.item_code,
+    rl.location,
+    doctype.name,
+    rl.name,
+    null
+from
+    `tabEquipment` eq,`tabRFID Logs` rl,`tabDocType` doctype
+where
+    eq.rfid_number = rl.id and
+    eq.name = "{5}" and
+    doctype.name = 'RFID Logs'
+
+order by `pd` desc
+	'''.format(equipment,equipment,equipment,equipment,equipment,equipment)
 	data = frappe.db.sql(query)
 	return data


### PR DESCRIPTION
Solving https://github.com/phamos-eu/zebra/issues/4.

What this does:
- Change the Equipment Log Book report to show RFID Logs also

![Captura de pantalla de 2023-05-10 15-40-41](https://github.com/phamos-eu/Equipment-Management/assets/6966715/24ac7127-6602-49bb-a21a-0ae4e1fa9327)
