### PR TITLE
New RFID Tag doctype and link field in Equipment

### DIFF
--- a/equipment_management/equipment_management/doctype/equipment/equipment.json
+++ b/equipment_management/equipment_management/doctype/equipment/equipment.json
@@ -12,6 +12,7 @@
   "image",
   "status",
   "equipment_details_section",
+  "equipment_name",
   "inv_nr",
   "last_location",
   "last_location_date",
@@ -128,8 +129,11 @@
   {
    "description": "c. RFID serial",
    "fieldname": "rfid_number",
-   "fieldtype": "Data",
-   "label": "RFID Number"
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "RFID Number",
+   "options": "RFID Tag",
+   "unique": 1
   },
   {
    "collapsible": 1,
@@ -243,6 +247,11 @@
    "fieldtype": "Text Editor",
    "label": "Item Desciption",
    "read_only": 1
+  },
+  {
+   "fieldname": "equipment_name",
+   "fieldtype": "Data",
+   "label": "Equipment Name"
   }
  ],
  "image_field": "image",
@@ -265,7 +274,7 @@
    "link_fieldname": "equipment"
   }
  ],
- "modified": "2023-05-12 09:58:36.494952",
+ "modified": "2023-08-02 08:51:16.090175",
  "modified_by": "Administrator",
  "module": "Equipment Management",
  "name": "Equipment",

--- a/equipment_management/equipment_management/doctype/rfid_tag/rfid_tag.js
+++ b/equipment_management/equipment_management/doctype/rfid_tag/rfid_tag.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, Deepak Kumar and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('RFID Tag', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/equipment_management/equipment_management/doctype/rfid_tag/rfid_tag.json
+++ b/equipment_management/equipment_management/doctype/rfid_tag/rfid_tag.json
@@ -1,0 +1,44 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:title",
+ "creation": "2023-08-02 08:36:53.037292",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "title"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title",
+   "unique": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2023-08-02 08:36:53.037292",
+ "modified_by": "Administrator",
+ "module": "Equipment Management",
+ "name": "RFID Tag",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "title_field": "title"
+}

--- a/equipment_management/equipment_management/doctype/rfid_tag/rfid_tag.py
+++ b/equipment_management/equipment_management/doctype/rfid_tag/rfid_tag.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, Deepak Kumar and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class RFIDTag(Document):
+	pass

--- a/equipment_management/equipment_management/doctype/rfid_tag/test_rfid_tag.py
+++ b/equipment_management/equipment_management/doctype/rfid_tag/test_rfid_tag.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, Deepak Kumar and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+class TestRFIDTag(unittest.TestCase):
+	pass


### PR DESCRIPTION
What is included:
- Create a RFID Tag doctype with just a title field.
![Captura de pantalla de 2023-08-02 09-00-55](https://github.com/phamos-eu/Equipment-Management/assets/6966715/6b6119c4-6e21-4c3b-b8a7-378ebef825bf)

- In the Equipment doctype we will add a link field to this doctype. This field is "unique".

![Captura de pantalla de 2023-08-02 08-59-11](https://github.com/phamos-eu/Equipment-Management/assets/6966715/a9b5c532-a134-4dd6-bfc9-603e4c3ef64f)
