### PR TITLE
Add type field in equipment

### DIFF
--- a/equipment_management/equipment_management/doctype/equipment/equipment.json
+++ b/equipment_management/equipment_management/doctype/equipment/equipment.json
@@ -8,6 +8,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "type",
   "naming_series",
   "image",
   "status",
@@ -259,6 +260,12 @@
    "fieldname": "generate_rfid_number",
    "fieldtype": "Button",
    "label": "Generate RFID Number"
+  },
+  {
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "label": "Type",
+   "options": "Equipment\nAccessorie"
   }
  ],
  "image_field": "image",
@@ -281,7 +288,7 @@
    "link_fieldname": "equipment"
   }
  ],
- "modified": "2024-01-11 17:02:16.667046",
+ "modified": "2024-01-17 16:42:05.192509",
  "modified_by": "Administrator",
  "module": "Equipment Management",
  "name": "Equipment",


### PR DESCRIPTION
In Equipment doctype, the logic asks for the `type` field to be present, so I added it.
![Captura de pantalla de 2024-01-17 16-46-57](https://github.com/phamos-eu/Equipment-Management/assets/6966715/23da8410-ebf4-442f-9c94-570a1a85d1b3)
