### PR TITLE
Fix: use frappe.DataTable

### DIFF
--- a/equipment_management/equipment_management/page/list_of_equipment_pa/list_of_equipment_pa.js
+++ b/equipment_management/equipment_management/page/list_of_equipment_pa/list_of_equipment_pa.js
@@ -25,7 +25,7 @@ frappe.pages['list-of-equipment-pa'].on_page_load = function(wrapper) {
     fetchData({});
 
     function renderTable(rows){
-        const datatable = new DataTable('#datatable', {
+        const datatable = new frappe.DataTable('#datatable', {
             columns: ["ID", "item Code", "Location", "Location Status", "Category", "Status", "Serial Number"],
             data: rows,
             checkboxColumn: true,


### PR DESCRIPTION
Error: DataTable was not found
`ReferenceError: DataTable is not defined`

Use the `frappe.DataTable` instead.